### PR TITLE
ToString when property not serializable by default

### DIFF
--- a/src/Umbraco.RestApi/Models/Mapping/ContentModelMapper.cs
+++ b/src/Umbraco.RestApi/Models/Mapping/ContentModelMapper.cs
@@ -74,13 +74,21 @@ namespace Umbraco.RestApi.Models
                 .ForMember(representation => representation.Properties, expression => expression.ResolveUsing(content =>
                 {
                     return content.Properties.ToDictionary(property => property.PropertyTypeAlias,
-                        property => property.Value);
+                        property => property.GetSerializableValue());
                 }));
 
             //config.CreateMap<SearchResult, ContentRepresentation>()
             //    //TODO: Lookup children
             //    .ForMember(content => content.HasChildren, expression => expression.Ignore())
             //    .ForMember(content => content.ContentType, expression => expression.Ignore())
+        }
+    }
+
+    public static class PublishedPropertyExtensions
+    {
+        public static object GetSerializableValue(this IPublishedProperty property)
+        {
+            return property.HasValue && property.Value.GetType().IsSerializable ? property.Value : property.Value?.ToString();
         }
     }
 }


### PR DESCRIPTION
When serializing some properties like 'HtmlString' it will error with a serialization exception. ToString on this properties fixes this