### PR TITLE
Fixing ability to render macros in published content

### DIFF
--- a/src/Umbraco.RestApi/Controllers/PublishedContentController.cs
+++ b/src/Umbraco.RestApi/Controllers/PublishedContentController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Web;

--- a/src/Umbraco.RestApi/Umbraco.RestApi.csproj
+++ b/src/Umbraco.RestApi/Umbraco.RestApi.csproj
@@ -175,6 +175,7 @@
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.Cors">
       <HintPath>..\packages\Microsoft.AspNet.Cors.5.2.3\lib\net45\System.Web.Cors.dll</HintPath>
     </Reference>


### PR DESCRIPTION
The code for the fix is from here: https://our.umbraco.org/forum/developers/extending-umbraco/74940-cannot-render-a-macro-when-there-is-no-current-publishedcontentrequest-custom-controllermodel